### PR TITLE
re-inserted accidentially dropped column

### DIFF
--- a/notebooks/EDA_preprocessing.ipynb
+++ b/notebooks/EDA_preprocessing.ipynb
@@ -61,7 +61,6 @@
     "assert len(building) == len(weather)\n",
     "\n",
     "building = (building\n",
-    ".drop(columns=[\"Heating Load [kWh]\"])\n",
     ".assign(\n",
     "        datetime = span('2008-01-02', '2011-12-31'),\n",
     "        holiday = lambda x: x[\"Day Type\"] == 8)\n",
@@ -70,7 +69,8 @@
     ".set_index(\"datetime\")\n",
     ".rename(columns=rename_cols)\n",
     ".assign(solar_generation_kW = lambda x: x.solar_generation_W_kW * pv_nominal_power_kW/1000)\n",
-    ")"
+    ")\n",
+    "building.columns"
    ]
   },
   {


### PR DESCRIPTION
I still had this line
.drop(columns=["Heating Load [kWh]"])
in the preprocessing notebook which only made sense for building 5